### PR TITLE
[maintainability-audit] Add dedicated spec coverage for Resumes::DocxTextExtractor (#48)

### DIFF
--- a/docs/maintainability_audits/README.md
+++ b/docs/maintainability_audits/README.md
@@ -17,12 +17,13 @@ This directory is the durable tracking home for the reusable Rails maintainabili
 - The next post-correction structural slice is complete: `ApplicationHelper` now delegates table/query behavior to `TableHelper`.
 - The next post-correction verification slice is complete: `Resumes::CloudImportProviderCatalog` now has dedicated shared-service coverage.
 - The next structural slice is complete: `LlmProvider` credential management extracted to `LlmProvider::CredentialManagement` concern with 15 focused examples.
+- The next verification slice is complete: `Resumes::DocxTextExtractor` now has 9 dedicated examples covering paragraph extraction, header/footer ordering, tab/break/CR handling, blank rejection, and error recovery.
 
 ### Pending
 
-- The next `implement-next` maintainability slice should come from the verification lane, because the last completed lane was structural.
-- The next verification candidate should start with `app/services/resumes/docx_text_extractor.rb`.
-- The remaining structural backlog includes `app/models/llm_provider.rb` (sync-state follow-up) and `Admin::JobLogsHelper` lower-priority open follow-ups.
+- The next `implement-next` maintainability slice should come from the structural lane, because the last completed lane was verification.
+- The next structural candidate is `app/models/llm_provider.rb` (sync-state follow-up).
+- The remaining verification backlog includes `app/services/resumes/pdf_text_extractor.rb`, `app/services/resumes/export_status_broadcaster.rb`, and `app/services/errors/tracker.rb`.
 
 ## Installed workflow
 
@@ -93,8 +94,8 @@ If this overview is stale, the workflow is considered incomplete even if code an
 
 ## Current round-robin state
 
-- Last completed lane: `structural`
-- Next preferred lane: `verification`
+- Last completed lane: `verification`
+- Next preferred lane: `structural`
 - Audit scope: `whole_codebase`
 - Max consecutive runs per lane: `1`
 
@@ -104,7 +105,6 @@ If this overview is stale, the workflow is considered incomplete even if code an
 
 ### Current verification candidates
 
-- `app/services/resumes/docx_text_extractor.rb`
 - `app/services/resumes/pdf_text_extractor.rb`
 - `app/services/resumes/export_status_broadcaster.rb`
 - `app/services/errors/tracker.rb`

--- a/docs/maintainability_audits/areas/broad-codebase-coverage-scan.md
+++ b/docs/maintainability_audits/areas/broad-codebase-coverage-scan.md
@@ -11,8 +11,8 @@ This file tracks the comprehensive coverage gap inventory discovered during a fu
 - Priority: `medium`
 - Status: `improved`
 - Recommended refactor shape: `add_targeted_specs`
-- Last reviewed: `2026-03-21T22:54:00Z`
-- Last changed: `2026-03-21T22:54:00Z`
+- Last reviewed: `2026-03-22T03:55:00Z`
+- Last changed: `2026-03-22T03:55:00Z`
 
 ## Hotspot summary
 
@@ -157,6 +157,11 @@ This file tracks the comprehensive coverage gap inventory discovered during a fu
 - Added `spec/services/llm/providers/base_client_spec.rb` (7 examples) covering shared GET/POST request behavior, timeout wiring, parsed error payload handling, invalid JSON/network failures, and the default unsupported image-method guards.
 - Re-verified adjacent LLM provider and consumer coverage in `spec/services/llm/providers/nvidia_build_client_spec.rb`, `spec/services/llm/providers/ollama_client_spec.rb`, `spec/services/llm/client_factory_spec.rb`, `spec/services/llm/provider_model_sync_service_spec.rb`, `spec/services/llm/parallel_text_runner_spec.rb`, and `spec/services/llm/parallel_vision_runner_spec.rb`.
 
+### Slice 31: resumes-docx-text-extractor-spec
+
+- Added `spec/services/resumes/docx_text_extractor_spec.rb` (9 examples) covering paragraph text extraction from `word/document.xml`, multi-run concatenation within a paragraph, header-before-document-before-footer ordering, sorted multi-header/multi-footer ordering, tab node conversion, break and carriage return node conversion, blank paragraph rejection, error recovery for invalid data, and empty result for zip without `word/document.xml`.
+- Re-verified adjacent source-text extraction coverage in `spec/services/resumes/source_text_resolver_spec.rb` and `spec/services/llm/resume_autofill_service_spec.rb`.
+
 ### Slice 30: resumes-cloud-import-provider-catalog-spec
 
 - Added `spec/services/resumes/cloud_import_provider_catalog_spec.rb` (6 examples) covering hydrated provider metadata from `.all`, known and unknown provider lookup via `.fetch`, and the `provider_unavailable`, `configured`, and `setup_required` feedback branches from `.launch_feedback`.
@@ -169,10 +174,11 @@ This file tracks the comprehensive coverage gap inventory discovered during a fu
 ## Pending
 
 - Remaining coverage gaps are now concentrated in low-priority shared service utilities and UI components.
+- `Resumes::DocxTextExtractor` now has 9 dedicated examples covering paragraph extraction, multi-run concatenation, header/footer ordering, tab/break/CR node handling, blank paragraph rejection, and error recovery for invalid and missing document data.
 
 ## Open follow-up keys
 
-- `add-resumes-docx-text-extractor-spec`
+- `add-resumes-pdf-text-extractor-spec`
 
 ## Closed follow-up keys
 
@@ -191,13 +197,14 @@ This file tracks the comprehensive coverage gap inventory discovered during a fu
 - `add-llm-providers-ollama-client-spec`
 - `add-llm-providers-base-client-spec`
 - `add-resumes-cloud-import-provider-catalog-spec`
+- `add-resumes-docx-text-extractor-spec`
 
 ## Verification
 
 - Specs:
-  - `bundle exec rspec spec/services/resumes/cloud_import_provider_catalog_spec.rb spec/presenters/resumes/source_step_state_spec.rb spec/helpers/resumes_helper_spec.rb spec/helpers/admin/settings_helper_spec.rb spec/requests/resume_source_imports_spec.rb` (55 examples, 0 failures)
+  - `bundle exec rspec spec/services/resumes/docx_text_extractor_spec.rb spec/services/resumes/source_text_resolver_spec.rb spec/services/llm/resume_autofill_service_spec.rb` (24 examples, 0 failures)
 - Lint or syntax:
-  - `ruby -c app/services/resumes/cloud_import_provider_catalog.rb spec/services/resumes/cloud_import_provider_catalog_spec.rb spec/presenters/resumes/source_step_state_spec.rb spec/helpers/resumes_helper_spec.rb spec/helpers/admin/settings_helper_spec.rb spec/requests/resume_source_imports_spec.rb` (Syntax OK)
+  - `ruby -c app/services/resumes/docx_text_extractor.rb spec/services/resumes/docx_text_extractor_spec.rb` (Syntax OK)
 
 ## Full missing-spec inventory (as of 2026-03-21)
 
@@ -211,7 +218,7 @@ This file tracks the comprehensive coverage gap inventory discovered during a fu
 ### Services (4 remaining missing)
 | File | Lines | Priority |
 |------|-------|----------|
-| `Resumes::DocxTextExtractor` | ~40 | low |
+| `Resumes::DocxTextExtractor` | ~40 | ✅ done |
 | `Resumes::PdfTextExtractor` | ~30 | low |
 | `Resumes::ExportStatusBroadcaster` | ~20 | low |
 | `Errors::Tracker` | ~30 | low |

--- a/docs/maintainability_audits/registry.yml
+++ b/docs/maintainability_audits/registry.yml
@@ -1,5 +1,5 @@
 version: 1
-updated_at: "2026-03-22T03:30:00Z"
+updated_at: "2026-03-22T03:55:00Z"
 workflow:
   status: ready
   path: ".windsurf/workflows/maintainability-audit.md"
@@ -9,7 +9,7 @@ tracking:
   overview_path: "docs/maintainability_audits/README.md"
   area_doc_template: "docs/maintainability_audits/areas/TEMPLATE.md"
   run_doc_template: "docs/maintainability_audits/runs/TEMPLATE.md"
-  latest_run: "docs/maintainability_audits/runs/2026-03-22-llm-provider-credential-management/00-overview.md"
+  latest_run: "docs/maintainability_audits/runs/2026-03-22-broad-codebase-docx-text-extractor/00-overview.md"
 area_statuses:
   - new
   - reviewed
@@ -42,13 +42,12 @@ categories:
 round_robin:
   overview_doc: "docs/maintainability_audits/README.md"
   audit_scope: "whole_codebase"
-  last_completed_lane: "structural"
-  next_preferred_lane: "verification"
+  last_completed_lane: "verification"
+  next_preferred_lane: "structural"
   max_consecutive_lane_runs: 1
   structural_candidate_paths:
     - "app/models/llm_provider.rb (sync-state follow-up)"
   verification_candidate_paths:
-    - "app/services/resumes/docx_text_extractor.rb"
     - "app/services/resumes/pdf_text_extractor.rb"
     - "app/services/resumes/export_status_broadcaster.rb"
     - "app/services/errors/tracker.rb"
@@ -280,7 +279,7 @@ areas:
     recommended_refactor_shape: "add_targeted_specs"
     area_doc_path: "docs/maintainability_audits/areas/broad-codebase-coverage-scan.md"
     open_follow_up_keys:
-      - "add-resumes-docx-text-extractor-spec"
+      - "add-resumes-pdf-text-extractor-spec"
     closed_follow_up_keys:
       - "add-application-job-spec"
       - "add-job-log-policy-spec"
@@ -297,14 +296,15 @@ areas:
       - "add-llm-providers-ollama-client-spec"
       - "add-llm-providers-base-client-spec"
       - "add-resumes-cloud-import-provider-catalog-spec"
-    last_reviewed_at: "2026-03-21T22:54:00Z"
-    last_changed_at: "2026-03-21T22:54:00Z"
-    next_step: "Add dedicated spec coverage for Resumes::DocxTextExtractor, then re-evaluate the remaining low-priority service coverage gaps."
-    cycle_count: 19
-    last_cycle_date: "2026-03-21T22:54:00Z"
+      - "add-resumes-docx-text-extractor-spec"
+    last_reviewed_at: "2026-03-22T03:55:00Z"
+    last_changed_at: "2026-03-22T03:55:00Z"
+    next_step: "Add dedicated spec coverage for Resumes::PdfTextExtractor, then re-evaluate remaining low-priority service coverage gaps."
+    cycle_count: 20
+    last_cycle_date: "2026-03-22T03:55:00Z"
     issues_found: 61
-    issues_resolved: 31
-    issues_remaining: 30
+    issues_resolved: 32
+    issues_remaining: 29
     regression_detected: false
   - area_key: "llm-provider-credential-management"
     title: "LlmProvider credential management extraction"

--- a/spec/services/resumes/docx_text_extractor_spec.rb
+++ b/spec/services/resumes/docx_text_extractor_spec.rb
@@ -1,0 +1,147 @@
+require 'rails_helper'
+require 'zip'
+
+RSpec.describe Resumes::DocxTextExtractor do
+  def build_docx(**xml_parts)
+    Zip::OutputStream.write_buffer do |zip|
+      xml_parts.each do |path, content|
+        zip.put_next_entry(path.to_s)
+        zip.write(content)
+      end
+    end.string
+  end
+
+  def word_xml(body_xml)
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:body>#{body_xml}</w:body>
+      </w:document>
+    XML
+  end
+
+  def paragraph(*runs)
+    "<w:p>#{runs.join}</w:p>"
+  end
+
+  def text_run(value)
+    "<w:r><w:t>#{value}</w:t></w:r>"
+  end
+
+  describe '#call' do
+    it 'extracts paragraph text from word/document.xml' do
+      docx = build_docx(
+        "word/document.xml" => word_xml(
+          paragraph(text_run("Pat Kumar")) +
+          paragraph(text_run("Senior Engineer"))
+        )
+      )
+
+      result = described_class.new(document_data: docx).call
+
+      expect(result).to eq("Pat Kumar\nSenior Engineer")
+    end
+
+    it 'concatenates multiple text runs within a single paragraph' do
+      docx = build_docx(
+        "word/document.xml" => word_xml(
+          paragraph(text_run("Pat"), text_run(" Kumar"))
+        )
+      )
+
+      result = described_class.new(document_data: docx).call
+
+      expect(result).to eq("Pat Kumar")
+    end
+
+    it 'reads headers before document and footers after document' do
+      header_xml = word_xml(paragraph(text_run("Header Content")))
+      document_xml = word_xml(paragraph(text_run("Body Content")))
+      footer_xml = word_xml(paragraph(text_run("Footer Content")))
+
+      docx = build_docx(
+        "word/header1.xml" => header_xml,
+        "word/document.xml" => document_xml,
+        "word/footer1.xml" => footer_xml
+      )
+
+      result = described_class.new(document_data: docx).call
+
+      expect(result).to eq("Header Content\nBody Content\nFooter Content")
+    end
+
+    it 'sorts multiple headers and footers by filename' do
+      header1 = word_xml(paragraph(text_run("First Header")))
+      header2 = word_xml(paragraph(text_run("Second Header")))
+      footer1 = word_xml(paragraph(text_run("First Footer")))
+      footer2 = word_xml(paragraph(text_run("Second Footer")))
+      document_xml = word_xml(paragraph(text_run("Body")))
+
+      docx = build_docx(
+        "word/header2.xml" => header2,
+        "word/header1.xml" => header1,
+        "word/document.xml" => document_xml,
+        "word/footer2.xml" => footer2,
+        "word/footer1.xml" => footer1
+      )
+
+      result = described_class.new(document_data: docx).call
+
+      expect(result).to eq("First Header\nSecond Header\nBody\nFirst Footer\nSecond Footer")
+    end
+
+    it 'converts tab nodes to tab characters' do
+      docx = build_docx(
+        "word/document.xml" => word_xml(
+          paragraph(text_run("Name"), "<w:r><w:tab/></w:r>", text_run("Pat Kumar"))
+        )
+      )
+
+      result = described_class.new(document_data: docx).call
+
+      expect(result).to eq("Name\tPat Kumar")
+    end
+
+    it 'converts break and carriage return nodes to newlines' do
+      docx = build_docx(
+        "word/document.xml" => word_xml(
+          paragraph(text_run("Line one"), "<w:r><w:br/></w:r>", text_run("Line two")) +
+          paragraph(text_run("After CR"), "<w:r><w:cr/></w:r>", text_run("Next"))
+        )
+      )
+
+      result = described_class.new(document_data: docx).call
+
+      expect(result).to eq("Line one\nLine two\nAfter CR\nNext")
+    end
+
+    it 'rejects blank paragraphs' do
+      docx = build_docx(
+        "word/document.xml" => word_xml(
+          paragraph(text_run("First")) +
+          paragraph +
+          paragraph(text_run("  ")) +
+          paragraph(text_run("Second"))
+        )
+      )
+
+      result = described_class.new(document_data: docx).call
+
+      expect(result).to eq("First\nSecond")
+    end
+
+    it 'returns an empty string for invalid document data' do
+      result = described_class.new(document_data: "not a zip file").call
+
+      expect(result).to eq("")
+    end
+
+    it 'returns an empty string for a zip without word/document.xml' do
+      docx = build_docx("other/file.txt" => "hello")
+
+      result = described_class.new(document_data: docx).call
+
+      expect(result).to eq("")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

**Workflow**: 
**Tracking key**: 

Closes #48