### PR TITLE
[resumebuilder-reference-rollout] Template variant carry-through: accent color continuity and choose-later framing (#50)

### DIFF
--- a/app/presenters/resumes/start_flow_state.rb
+++ b/app/presenters/resumes/start_flow_state.rb
@@ -62,6 +62,22 @@ module Resumes
       resume.template_id
     end
 
+    def selected_accent_color
+      resume.accent_color
+    end
+
+    def accent_color_differs_from_template_default?
+      return false if resume.template.blank?
+
+      selected_accent_color != resume.template.render_layout_config.fetch("accent_color")
+    end
+
+    def resume_settings_params
+      return {} unless accent_color_differs_from_template_default?
+
+      { accent_color: selected_accent_color }
+    end
+
     private
       attr_reader :resume, :step
   end

--- a/app/views/resumes/_start_flow_experience_step.html.erb
+++ b/app/views/resumes/_start_flow_experience_step.html.erb
@@ -11,14 +11,12 @@
 
       <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
         <% start_flow_state.experience_options.each do |option| %>
+          <% resume_params = { intake_details: { experience_level: option.fetch(:value) } } %>
+          <% resume_params[:settings] = start_flow_state.resume_settings_params if start_flow_state.resume_settings_params.present? %>
           <%= link_to new_resume_path(
                 step: start_flow_state.next_step_for_experience(option.fetch(:value)),
                 template_id: start_flow_state.selected_template_id,
-                resume: {
-                  intake_details: {
-                    experience_level: option.fetch(:value)
-                  }
-                }
+                resume: resume_params
               ),
               class: [ui_inset_panel_classes(tone: :subtle), "block transition hover:border-canvas-300 hover:bg-canvas-50/92 focus:outline-none focus:ring-2 focus:ring-ink-400/30"].join(" ") do %>
             <div class="space-y-2">

--- a/app/views/resumes/_start_flow_student_step.html.erb
+++ b/app/views/resumes/_start_flow_student_step.html.erb
@@ -11,15 +11,12 @@
 
       <div class="grid gap-3 sm:grid-cols-2">
         <% start_flow_state.student_options.each do |option| %>
+          <% resume_params = { intake_details: { experience_level: start_flow_state.selected_experience_level, student_status: option.fetch(:value) } } %>
+          <% resume_params[:settings] = start_flow_state.resume_settings_params if start_flow_state.resume_settings_params.present? %>
           <%= link_to new_resume_path(
                 step: "setup",
                 template_id: start_flow_state.selected_template_id,
-                resume: {
-                  intake_details: {
-                    experience_level: start_flow_state.selected_experience_level,
-                    student_status: option.fetch(:value)
-                  }
-                }
+                resume: resume_params
               ),
               class: [ui_inset_panel_classes(tone: :subtle), "block transition hover:border-canvas-300 hover:bg-canvas-50/92 focus:outline-none focus:ring-2 focus:ring-ink-400/30"].join(" ") do %>
             <div class="space-y-2">
@@ -31,16 +28,13 @@
       </div>
 
       <div class="flex flex-wrap items-center gap-3">
+        <% skip_resume_params = { intake_details: { experience_level: start_flow_state.selected_experience_level, student_status: "" } } %>
+        <% skip_resume_params[:settings] = start_flow_state.resume_settings_params if start_flow_state.resume_settings_params.present? %>
         <%= link_to t(".skip_for_now"),
           new_resume_path(
             step: "setup",
             template_id: start_flow_state.selected_template_id,
-            resume: {
-              intake_details: {
-                experience_level: start_flow_state.selected_experience_level,
-                student_status: ""
-              }
-            }
+            resume: skip_resume_params
           ),
           class: ui_button_classes(:secondary) %>
       </div>

--- a/app/views/resumes/_template_picker_compact.html.erb
+++ b/app/views/resumes/_template_picker_compact.html.erb
@@ -16,6 +16,8 @@
     </div>
   </div>
 
+  <p class="text-sm leading-6 text-ink-700/80 choose-later-note"><%= t("#{compact_text_scope}.choose_later_note") %></p>
+
   <details class="group">
     <summary class="flex cursor-pointer list-none items-center justify-between gap-3 [&::-webkit-details-marker]:hidden">
       <div class="flex items-center gap-3">

--- a/config/locales/views/resumes.en.yml
+++ b/config/locales/views/resumes.en.yml
@@ -275,6 +275,8 @@ en:
       fast_start_pill: "Fast start"
       fast_start_description: "Open the full browser only if you want to compare more options."
       open_marketplace: "Open marketplace"
+      choose_later: "Choose later"
+      choose_later_note: "Skip template selection for now. You can always switch templates from the finalize step after the draft is created."
       recommended_pill: "Recommended for this draft"
       recommended_description: "Based on the experience details you chose, these templates are likely to fit best."
       preview_selected_badge: "Selected"

--- a/docs/resumebuilder_rollouts/registry.yml
+++ b/docs/resumebuilder_rollouts/registry.yml
@@ -106,26 +106,34 @@ slices:
   - slice_key: template-variant-carry-through
     title: Template variant carry-through
     page_family: resumes-new-and-templates-index
-    status: not_started
+    status: verified
     priority: medium
     reference_source_docs:
       - docs/references/resumebuilder/live-flow-comparison-2026-03-20/15-implementation-plan.md
       - docs/references/resumebuilder/e2e-template-flex-audit-2026-03-21/02-template-led-builder-flow.md
       - docs/references/resumebuilder/e2e-template-flex-audit-2026-03-21/04-template-flexibility-matrix.md
     current_app_surfaces:
+      - app/presenters/resumes/start_flow_state.rb
       - app/presenters/resumes/template_picker_state.rb
+      - app/views/resumes/_start_flow_experience_step.html.erb
+      - app/views/resumes/_start_flow_student_step.html.erb
       - app/views/resumes/_template_picker.html.erb
       - app/views/resumes/_template_picker_compact.html.erb
       - app/views/templates/index.html.erb
       - app/presenters/templates/marketplace_state.rb
-    open_gap_keys:
+    open_gap_keys: []
+    closed_gap_keys:
       - template-variant-carry-through-precreate-continuity
       - template-variant-carry-through-choose-later-framing
-    closed_gap_keys: []
     verification_specs:
+      - spec/presenters/resumes/start_flow_state_spec.rb
       - spec/requests/resumes_spec.rb
       - spec/requests/templates_spec.rb
-    latest_run: ""
-    cycle_count: 0
+      - spec/presenters/resumes/template_picker_state_spec.rb
+      - spec/presenters/templates/marketplace_state_spec.rb
+    latest_run: docs/resumebuilder_rollouts/runs/2026-03-22-template-variant-carry-through/00-overview.md
+    cycle_count: 1
     regression_detected: false
+    github_issue_number: 50
+    github_pr_number: 52
     next_recommended_slice: ""

--- a/docs/resumebuilder_rollouts/slices/template-variant-carry-through.md
+++ b/docs/resumebuilder_rollouts/slices/template-variant-carry-through.md
@@ -1,0 +1,66 @@
+# Template Variant Carry-Through
+
+## Slice key
+
+`template-variant-carry-through`
+
+## Page family
+
+`resumes-new-and-templates-index`
+
+## Reference source
+
+- `docs/references/resumebuilder/e2e-template-flex-audit-2026-03-21/02-template-led-builder-flow.md`
+- `docs/references/resumebuilder/e2e-template-flex-audit-2026-03-21/04-template-flexibility-matrix.md`
+- `docs/references/resumebuilder/live-flow-comparison-2026-03-20/15-implementation-plan.md`
+
+## Problem statement
+
+The hosted ResumeBuilder.com app allows users to select per-card color variants before committing to a template and offers a named "Choose later" affordance in the in-app template chooser. Our app already supports accent variant selection in the marketplace and setup picker, but two gaps remained:
+
+1. **Pre-create continuity**: When a user selects a non-default accent variant in the marketplace and clicks "Use this template", the accent color was carried into the setup form. However, transitioning through the experience gate or student follow-up steps dropped the `resume[settings][accent_color]` from the link params, resetting the accent to the template default.
+
+2. **Choose-later framing**: The hosted app includes an explicit "Choose later" button. Our setup form already allowed skipping template selection (the picker is collapsed by default), but lacked an explicit named affordance communicating that deferring is expected and safe.
+
+## Completed work
+
+### Gap 1: Accent color carry-through (precreate-continuity)
+
+- Added `selected_accent_color`, `accent_color_differs_from_template_default?`, and `resume_settings_params` methods to `Resumes::StartFlowState`
+- Updated `_start_flow_experience_step.html.erb` so each experience option link includes `resume[settings][accent_color]` when the accent differs from the template default
+- Updated `_start_flow_student_step.html.erb` so each student option link and the skip link include `resume[settings][accent_color]` when applicable
+
+### Gap 2: Choose-later framing
+
+- Added `choose_later` and `choose_later_note` locale keys to `config/locales/views/resumes.en.yml` under `resumes.template_picker_compact`
+- Updated `_template_picker_compact.html.erb` to render a "Choose later" note inside the compact picker summary area
+- The finalize step already had its own contextual `choose_later_note` in `config/locales/views/resume_builder.en.yml`
+
+## Current app surfaces
+
+- `app/presenters/resumes/start_flow_state.rb`
+- `app/views/resumes/_start_flow_experience_step.html.erb`
+- `app/views/resumes/_start_flow_student_step.html.erb`
+- `app/views/resumes/_template_picker_compact.html.erb`
+- `app/presenters/resumes/template_picker_state.rb`
+- `app/views/resumes/_template_picker.html.erb`
+- `app/views/templates/index.html.erb`
+- `app/presenters/templates/marketplace_state.rb`
+- `config/locales/views/resumes.en.yml`
+
+## Verification
+
+```bash
+bundle exec rspec spec/presenters/resumes/start_flow_state_spec.rb spec/requests/resumes_spec.rb spec/requests/templates_spec.rb spec/presenters/resumes/template_picker_state_spec.rb spec/presenters/templates/marketplace_state_spec.rb
+```
+
+## Remaining gaps
+
+None. Both gap keys are now closed.
+
+## Next recommended slice
+
+Evaluate the deferred backlog for the next highest-value slice. Candidates include:
+- Late-stage formatting depth (font family, typography controls)
+- Unified post-build customization hub
+- Earlier variant previews in picker cards

--- a/spec/presenters/resumes/start_flow_state_spec.rb
+++ b/spec/presenters/resumes/start_flow_state_spec.rb
@@ -122,4 +122,25 @@ RSpec.describe Resumes::StartFlowState do
       expect(start_flow_state.next_step_for_experience('three_to_five_years')).to eq('setup')
     end
   end
+
+  describe '#resume_settings_params' do
+    context 'when accent color matches the template default' do
+      it 'returns an empty hash' do
+        expect(start_flow_state.resume_settings_params).to eq({})
+      end
+    end
+
+    context 'when accent color differs from the template default' do
+      let(:resume) do
+        build(:resume, template:, template_id: template.id,
+              intake_details:,
+              settings: { "accent_color" => "#dc2626" })
+      end
+
+      it 'returns accent color for carry-through' do
+        expect(start_flow_state.resume_settings_params).to eq({ accent_color: "#dc2626" })
+        expect(start_flow_state).to be_accent_color_differs_from_template_default
+      end
+    end
+  end
 end

--- a/spec/requests/resumes_spec.rb
+++ b/spec/requests/resumes_spec.rb
@@ -105,6 +105,54 @@ RSpec.describe 'Resumes', type: :request do
       expect(response.body).not_to include(I18n.t('resumes.editor_finalize_step.template_picker.fast_start_description'))
     end
 
+    it 'carries accent color through experience step links when a non-default variant is selected' do
+      classic_template = create(
+        :template,
+        name: 'Classic Ivory',
+        slug: 'classic-ivory-carry',
+        layout_config: ResumeTemplates::Catalog.default_layout_config(family: 'classic')
+      )
+
+      get new_resume_path, params: {
+        template_id: classic_template.id,
+        resume: {
+          settings: {
+            accent_color: '#334155'
+          }
+        }
+      }
+
+      expect(response).to have_http_status(:ok)
+      document = Nokogiri::HTML.parse(response.body)
+      experience_links = document.css('a').select { |a| a['href']&.include?('experience_level') }
+
+      expect(experience_links).not_to be_empty
+      experience_links.each do |link|
+        href = link['href']
+        expect(href).to include('accent_color'), "expected experience link to carry accent_color: #{href}"
+      end
+    end
+
+    it 'shows the choose-later note inside the setup template picker disclosure' do
+      template
+
+      get new_resume_path, params: {
+        step: 'setup',
+        resume: {
+          intake_details: {
+            experience_level: 'three_to_five_years'
+          }
+        }
+      }
+
+      expect(response).to have_http_status(:ok)
+      document = Nokogiri::HTML.parse(response.body)
+      template_disclosure = document.at_css('details[data-resume-template-disclosure]')
+
+      expect(template_disclosure).to be_present
+      expect(template_disclosure.text).to include(I18n.t('resumes.template_picker_compact.choose_later_note'))
+    end
+
     it 'preserves a requested accent selection in the setup picker state' do
       classic_template = create(
         :template,
@@ -203,6 +251,28 @@ RSpec.describe 'Resumes', type: :request do
       expect(workspace_aside.text).to include(I18n.t('resumes.index.quick_actions.counts_summary', ready_count: 1, draft_count: 1))
       expect(workspace_aside.text).to include(I18n.t('resumes.index.quick_actions.focus_note'))
       expect(workspace_aside.css('a, button').map { |element| element.text.squish }).to include(I18n.t('resumes.index.quick_actions.create_resume'))
+    end
+  end
+
+  describe 'GET /resumes/:id' do
+    it 'keeps the desktop preview rail focused on actions and status without duplicate explainer copy' do
+      resume = create(:resume, user:, template:)
+
+      get resume_path(resume)
+
+      expect(response).to have_http_status(:ok)
+
+      document = Nokogiri::HTML.parse(response.body)
+      desktop_actions_panel = document.css('aside').last
+
+      expect(response.body).to include(I18n.t('resumes.show.preview_title'))
+      expect(desktop_actions_panel).to be_present
+      expect(desktop_actions_panel.text).to include(I18n.t('resumes.show.desktop_actions.title'))
+      expect(desktop_actions_panel.text).not_to include(I18n.t('resumes.show.what_this_shows.eyebrow'))
+      expect(desktop_actions_panel.text).not_to include(I18n.t('resumes.show.what_this_shows.description'))
+      expect(desktop_actions_panel.text).to include(I18n.t('resumes.export_actions_state.actions.export_pdf'))
+      expect(desktop_actions_panel.text).to include(I18n.t('resumes.export_actions_state.actions.download_text'))
+      expect(desktop_actions_panel.text).to include(I18n.t('resumes.export_status_state.widget.eyebrow'))
     end
   end
 
@@ -427,6 +497,31 @@ RSpec.describe 'Resumes', type: :request do
       expect(persisted_entry_card.at_css('summary').text).not_to include(fallback_text)
       expect(new_entry_card).to be_present
       expect(new_entry_card.at_css('summary').text).to include(I18n.t('resumes.entry_form.supporting_text.new_with_existing'))
+    end
+
+    it 'renders the summary step without a duplicate step header and starts with the library panel' do
+      resume = create(
+        :resume,
+        user:,
+        template:,
+        headline: 'Software Engineer',
+        intake_details: { 'experience_level' => 'three_to_five_years' }
+      )
+
+      get edit_resume_path(resume), params: { step: 'summary' }
+
+      expect(response).to have_http_status(:ok)
+
+      document = Nokogiri::HTML.parse(response.body)
+      step_content = document.at_css("##{ActionView::RecordIdentifier.dom_id(resume, :editor_step_content)}")
+
+      expect(step_content.text).to include(I18n.t('resumes.editor_summary_step.library.title'))
+      expect(step_content.text).to include(I18n.t('resumes.editor_summary_step.suggestions_title'))
+      expect(step_content.text).to include(I18n.t('resumes.editor_summary_step.summary_label'))
+
+      step_header_titles = step_content.css('h3').map { |h| h.text.squish }
+      step_title = I18n.t('resume_builder.step_registry.steps.summary.title')
+      expect(step_header_titles).not_to include(step_title)
     end
 
     it 'collapses section header actions on section-step pages while keeping finalize inline' do


### PR DESCRIPTION
## Summary

**Workflow**: 
**Tracking key**: 

Closes #50